### PR TITLE
feat: Release drafter

### DIFF
--- a/.github/workflows/01-call_add_label_to_pr.yaml
+++ b/.github/workflows/01-call_add_label_to_pr.yaml
@@ -1,0 +1,11 @@
+name: Add label to PR
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  add_label_to_pr:
+    uses: Sincpro-SRL/.github/.github/workflows/01-add_label_to_pr.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/02-release_draft.yaml
+++ b/.github/workflows/02-release_draft.yaml
@@ -1,0 +1,11 @@
+name: Create release draft
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release_draft:
+    uses: Sincpro-SRL/.github/.github/workflows/03-release_draft.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/01-add_label_to_pr.yaml
+++ b/01-add_label_to_pr.yaml
@@ -1,0 +1,17 @@
+name: Add labels to PRs
+
+on:
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+jobs:
+  start_labeling:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next release notes as pull requests that are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/03-release_draft.yml
+++ b/03-release_draft.yml
@@ -1,0 +1,33 @@
+name: Release draft
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_draft:
+    name: Create / Update draft release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Verify Author
+        id: check-author
+        run: |
+          AUTHOR=$(git log -1 --pretty=format:'%ae')
+          if [ "$AUTHOR" = "actions@github.com" ]; then
+            echo "is-bot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-bot=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run Release Drafter
+        if: steps.check-author.outputs.is-bot == 'false'
+        uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/files/.github/release-drafter.yml
+++ b/files/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "🚀 Features"
+    label: "feature"
+  - title: "🛠️ Maintenance"
+    label: "maintenance"
+  - title: "🐛 Bug Fixes"
+    label: "bug"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "feature"
+  patch:
+    labels:
+      - "maintenance"
+      - "bug"
+  default: patch
+
+replacers:
+  - search: '/([A-Z]{2,6}-\d{1,6}-\d{1,6})/g'
+    replace: "[$1](https://notion.so/sincpro/$1)"
+
+autolabeler:
+  - label: "maintenance"
+    title:
+      - "/^chore.+/i"
+  - label: "bug"
+    title:
+      - "/^fix.+/i"
+  - label: "feature"
+    title:
+      - "/^feat.+/i"
+  - label: "major"
+    title:
+      - "/^major.+/i"
+
+template: |
+  ## What's Changed
+  $CHANGES

--- a/files/.github/semantic.yml
+++ b/files/.github/semantic.yml
@@ -1,0 +1,3 @@
+# Default types can be checked here
+# https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+titleOnly: true


### PR DESCRIPTION
This pull request introduces a set of GitHub Actions workflows and configuration files to automate pull request labeling and release drafting, as well as to standardize release note generation and semantic commit enforcement. The main changes include adding reusable workflow files for labeling PRs and creating release drafts, configuring the release drafter, and setting up semantic commit rules.

**Workflow automation:**

* Added `.github/workflows/01-call_add_label_to_pr.yaml` to automatically add labels to pull requests by invoking a reusable workflow from the organization's workflow repository.
* Added `.github/workflows/02-release_draft.yaml` to automate the creation of release drafts on pushes to the `main` branch, using a reusable workflow.
* Introduced `01-add_label_to_pr.yaml` to define a job for labeling PRs using the `release-drafter` action.
* Added `03-release_draft.yml` to create or update draft releases, with steps for checking out code, verifying the author, and running the release drafter only for non-bot commits.

**Release notes and semantic configuration:**

* Added `files/.github/release-drafter.yml` to configure release note generation, including name and tag templates, categorization, version resolution, autolabeling rules, and a custom template for change logs.
* Added `files/.github/semantic.yml` to enforce semantic commit messages based on titles only.