### PR TITLE
chore: fix branch ref

### DIFF
--- a/.github/workflows/01-call_add_label_to_pr.yaml
+++ b/.github/workflows/01-call_add_label_to_pr.yaml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   add_label_to_pr:
-    uses: Sincpro-SRL/.github/workflows/01-add_label_to_pr.yaml
+    uses: Sincpro-SRL/.github/workflows/01-add_label_to_pr.yaml@main
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/02-release_draft.yaml
+++ b/.github/workflows/02-release_draft.yaml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release_draft:
-    uses: Sincpro-SRL/.github/workflows/03-release_draft.yaml
+    uses: Sincpro-SRL/.github/workflows/03-release_draft.yaml@main
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request updates workflow job references in GitHub Actions configuration files to explicitly use the `main` branch of the shared workflow repositories. This ensures that the latest version from the `main` branch is always used when these workflows are triggered.

Workflow reference updates:

* [`.github/workflows/01-call_add_label_to_pr.yaml`](diffhunk://#diff-f7d63ea645864e4a49a0a6896080c3e7d889354492432f60471fc3beae4a2e6fL9-R9): Updated the `add_label_to_pr` job to reference `Sincpro-SRL/.github/workflows/01-add_label_to_pr.yaml@main` instead of the default branch.
* [`.github/workflows/02-release_draft.yaml`](diffhunk://#diff-be9d267ca075d5f530c5b6d0fd428609ec1c3dbe2aaedc60d37bc07e2bc97503L9-R9): Updated the `release_draft` job to reference `Sincpro-SRL/.github/workflows/03-release_draft.yaml@main` instead of the default branch.

## Checklist

-   [ ] Did you test manually the changes