### PR TITLE
feat: Add update project version workflow

### DIFF
--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -4,17 +4,15 @@ on:
   push:
     branches:
       - main
-  
   workflow_call: {}
 
 jobs:
   release_draft:
     name: Create / Update draft release
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify Author
         id: check-author
@@ -33,3 +31,10 @@ jobs:
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_version:
+    name: Update project version
+    needs: release_draft
+    if: needs.release_draft.result == 'success'
+    uses: Sincpro-SRL/.github/.github/workflows/03.01-update-project-version.yaml@main
+    secrets: inherit

--- a/.github/workflows/03.01-update-project-version.yaml
+++ b/.github/workflows/03.01-update-project-version.yaml
@@ -3,14 +3,16 @@ name: Update project version
 on:
   workflow_run:
     workflows:
-      - Release draft
+      - "Release draft"
     types:
       - completed
+  workflow_call:
 
 jobs:
-
   update_project_version:
     runs-on: ubuntu-latest
+
+    if: github.event_name == 'workflow_call' || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Release draft' && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -48,13 +50,13 @@ jobs:
       - name: Update main branch with the new version
         run: |
           git checkout main
-          if git diff --quiet pyproject.toml; then
-            echo "No hay cambios en pyproject.toml. No se realizará commit ni push."
+          if git diff --quiet; then
+            echo "No changes detected. No commit or push will be performed."
           else
             git config user.name "GitHub Actions"
             git config user.email "actions@github.com"
-            git add pyproject.toml
-            git commit -m "chore: Actualización de versión a ${{ steps.get-latest-release.outputs.tag_name }}"
+            git add .
+            git commit -m "chore: Update version to ${{ steps.get-latest-release.outputs.tag_name }}"
             git push origin main
           fi
         env:

--- a/.github/workflows/03.01-update-project-version.yaml
+++ b/.github/workflows/03.01-update-project-version.yaml
@@ -12,7 +12,6 @@ jobs:
   update_project_version:
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'workflow_call' || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Release draft' && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/04-update-project-version.yaml
+++ b/.github/workflows/04-update-project-version.yaml
@@ -1,0 +1,61 @@
+name: Update project version
+
+on:
+  workflow_run:
+    workflows:
+      - Release draft
+    types:
+      - completed
+
+jobs:
+
+  update_project_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get latest release version
+        id: get-latest-release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const allReleases = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            
+            if (allReleases.data.length === 0) {
+              core.info('No previous releases found');
+              core.setOutput('tag_name', '');
+              return;
+            }
+            const latestRelease = allReleases.data[0];
+            const tagName = latestRelease.tag_name;
+            core.info(`Latest release tag name: ${tagName}`);
+            const sanitizedTagName = tagName.replace(/[^0-9.]/g, '');
+            core.info(`version to update: ${sanitizedTagName}`);
+            core.setOutput('tag_name', sanitizedTagName);
+
+      - name: Update project version
+        run: |
+          VERSION=${{ steps.get-latest-release.outputs.tag_name }}
+          echo "Updating version to $VERSION"
+          if [ -n "$VERSION" ]; then
+            make update-version VERSION=$VERSION
+          fi
+
+      - name: Update main branch with the new version
+        run: |
+          git checkout main
+          if git diff --quiet pyproject.toml; then
+            echo "No hay cambios en pyproject.toml. No se realizará commit ni push."
+          else
+            git config user.name "GitHub Actions"
+            git config user.email "actions@github.com"
+            git add pyproject.toml
+            git commit -m "chore: Actualización de versión a ${{ steps.get-latest-release.outputs.tag_name }}"
+            git push origin main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+prepare-environment:
+	@echo "Template to prepare environment, Install core libraries like pip, pipx, npm, etc"
+
+init: prepare-environment
+	@echo "Template to init dependencies project"
+
+format:
+	@echo "Template to format code"
+
+verify-format:
+	@echo "Template to verify code format"
+
+test:
+	@echo "Template to run tests"
+
+update-version:
+ifndef VERSION
+	$(error VERSION is required. Usage: make update-version VERSION=1.2.3)
+endif
+	@echo "Template to update project version $(VERSION) based on make parameter"
+
+publish:
+	@echo "Template to publish the artifact"
+
+deploy:
+	@echo "Template to deploy the artifact only if is service"
+
+.PHONY: prepare-environment init format verify-format test update-version publish deploy
+
+


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request introduces automation for updating the project version after a release and scaffolds a standardized set of Makefile targets for project operations. The main focus is to streamline post-release version management and establish a consistent workflow for common development tasks.

**CI/CD Automation:**

* Adds a new GitHub Actions workflow (`.github/workflows/04-update-project-version.yaml`) that triggers after the "Release draft" workflow completes. This workflow:
  * Retrieves the latest release version, sanitizes the tag, and updates the project version using `make update-version`.
  * Commits and pushes changes to `pyproject.toml` on the `main` branch if the version was updated.

**Build System Scaffolding:**

* Introduces template targets in the `Makefile` for key project operations, including environment preparation, initialization, code formatting, testing, version updating, publishing, and deployment. These targets currently print placeholder messages and are ready to be implemented with actual commands.

## Checklist

-   [ ] Did you test manually the changes