### PR TITLE
chore: add default env for common python

### DIFF
--- a/.github/workflows/02-check_code.yaml
+++ b/.github/workflows/02-check_code.yaml
@@ -19,6 +19,10 @@ on:
         type: string
         default: '["default"]'
 
+env:
+  GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
+  POETRY_PYPI_TOKEN: ${{ secrets.POETRY_PYPI_TOKEN }}
+
 jobs:
   checks:
     name: Run checks (${{ matrix.env }})


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request makes a small update to the GitHub Actions workflow by adding environment variables for package publishing tokens. This change ensures that the necessary authentication tokens are available for any steps that require publishing to Gemfury or PyPI.

- CI/CD configuration:
  * [`.github/workflows/02-check_code.yaml`](diffhunk://#diff-4347c828754685d6d8bfb8a5d021211cd598835cb9295a8b06dde8179d2ba894R22-R25): Added `GEMFURY_PUSH_TOKEN` and `POETRY_PYPI_TOKEN` as environment variables to the workflow to support package publishing.

## Checklist

- [ ] Did you test manually the changes
