### PR TITLE
chore: wait release draft finish to update the project

### DIFF
--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -44,6 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update_project_version:
+    needs: release_draft
     name: Update project version
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes


This pull request makes a minor update to the GitHub Actions workflow by ensuring that the `update_project_version` job depends on the successful completion of the `release_draft` job. This change helps enforce the correct order of execution in the release process.
## Checklist

- [ ] Did you test manually the changes
