### PR TITLE
fix: Init env in update version process

### DIFF
--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -78,11 +78,11 @@ jobs:
             const sanitizedTagName = tagName.replace(/[^0-9.]/g, '');
             core.info(`version to update: ${sanitizedTagName}`);
             core.setOutput('tag_name', sanitizedTagName);
-            
+
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
-          environment: ${{ matrix.env }}      
+          environment: ${{ matrix.env }}
 
       - name: Update project version
         run: |


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request adds an environment preparation step to the release draft workflow. Now, before updating the project version, the workflow will run a custom action to set up the environment according to the specified matrix value.

Workflow improvements:

* [`.github/workflows/03-release_draft.yaml`](diffhunk://#diff-38d18142995627afcf3d4dc8291c87f45347fd11a45652c82f309b0c08d7c4a2R82-R86): Added a `Prepare environment` step using the `.github/actions/prepare-env` action, which takes the environment from the workflow matrix as input.

## Checklist

- [ ] Did you test manually the changes
