### PR TITLE
Sp 2025 2107 3

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,3 @@
-filter-by-commitish: true
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 

--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -75,30 +75,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const currentBranch = '${{ steps.branch-context.outputs.branch }}';
             const allReleases = await github.rest.repos.listReleases({
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
 
-            // Filter releases only from the current branch with null check
-            const branchReleases = allReleases.data.filter(release => {
-              if (!release.target_commitish) {
-                return false;
-              }
-              return release.target_commitish === currentBranch;
-            });
-
-            core.info(`Found ${branchReleases.length} releases for branch: ${currentBranch}`);
-
-            if (branchReleases.length === 0) {
-              core.info(`No previous releases found for branch: ${currentBranch}`);
+            if (allReleases.data.length === 0) {
+              core.info('No previous releases found');
               core.setOutput('tag_name', '');
               return;
             }
-            const latestRelease = branchReleases[0];
+            const latestRelease = allReleases.data[0];
             const tagName = latestRelease.tag_name;
-            core.info(`Latest release tag name: ${tagName} (commitish: ${latestRelease.target_commitish})`);
+            core.info(`Latest release tag name: ${tagName}`);
             const sanitizedTagName = tagName.replace(/[^0-9.]/g, '');
             core.info(`version to update: ${sanitizedTagName}`);
             core.setOutput('tag_name', sanitizedTagName);


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request updates the release drafting workflow to simplify how releases are filtered and tagged. The main change is that releases are no longer filtered by branch, which streamlines the process for identifying the latest release.

**Release workflow simplification:**

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaL1): Removed the `filter-by-commitish: true` setting, so releases are no longer filtered by branch commitish.
* [`.github/workflows/03-release_draft.yaml`](diffhunk://#diff-38d18142995627afcf3d4dc8291c87f45347fd11a45652c82f309b0c08d7c4a2L78-R90): Updated the release selection logic in the GitHub Actions workflow to use all releases instead of filtering by the current branch, and removed related code for branch filtering.

## Checklist

- [ ] Did you test manually the changes
