### PR TITLE
chore(SP-2025-2107): Add latest tag if not exists release

### DIFF
--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -34,6 +34,22 @@ jobs:
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
+      - name: Get last version from tags
+        id: last-version
+        run: |
+          # Get the last tag reachable from current branch
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -n "$LAST_TAG" ]; then
+            echo "tag=$LAST_TAG" >> $GITHUB_OUTPUT
+            echo "has_tag=true" >> $GITHUB_OUTPUT
+            echo "✅ Found last tag: $LAST_TAG"
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+            echo "has_tag=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No tags found on this branch (new repository or branch)"
+          fi
+
       - name: Verify Author
         id: check-author
         run: |
@@ -50,6 +66,7 @@ jobs:
         with:
           disable-autolabeler: true
           commitish: ${{ steps.branch-context.outputs.branch }}
+          version: ${{ steps.last-version.outputs.has_tag == 'true' && steps.last-version.outputs.tag || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request updates the release workflow to automatically detect the latest version tag from the current branch and use it in the release draft process. This enhancement streamlines version management and ensures that release drafts are based on the most recent tag when available.

Release workflow improvements:

* Added a step to retrieve the last reachable version tag from the current branch, setting outputs for the tag value and whether a tag was found. (`.github/workflows/03-release_draft.yaml`)
* Updated the release draft step to use the detected version tag if available, improving accuracy of release versioning. (`.github/workflows/03-release_draft.yaml`)

## Checklist

- [ ] Did you test manually the changes
