### PR TITLE
fix(SP-2025-2107): Fix release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,4 @@
 filter-by-commitish: true
-include-pre-releases: true
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 

--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -66,7 +66,6 @@ jobs:
         with:
           disable-autolabeler: true
           commitish: ${{ steps.branch-context.outputs.branch }}
-          version: ${{ steps.last-version.outputs.has_tag == 'true' && steps.last-version.outputs.tag || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request makes minor configuration changes to the release drafting workflow, focusing on simplifying the release process and improving version handling.

Release workflow configuration:

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaL2): Removed the `include-pre-releases` setting to prevent pre-releases from being included in the drafted release notes.
* [`.github/workflows/03-release_draft.yaml`](diffhunk://#diff-38d18142995627afcf3d4dc8291c87f45347fd11a45652c82f309b0c08d7c4a2L69): Removed the logic that conditionally sets the release version based on the presence of an existing tag, streamlining the workflow configuration.

## Checklist

- [ ] Did you test manually the changes
